### PR TITLE
Ajuste no layout da página de arquivo de tags

### DIFF
--- a/source/_views/post.twig
+++ b/source/_views/post.twig
@@ -23,7 +23,8 @@
             <p class="tags">
                 Tags:
                 {% for tag in page.tags %}
-                    <a href="{{ page.tag_html_index_permalinks[tag] }}">{{ tag }}</a>{% if not loop.last %}, {% endif %}
+                    {% set tag_slug = tag|url_encode(true) %}
+                    <a href="/news/tags/{{ tag_slug }}">{{ tag }}</a>{% if not loop.last %}, {% endif %}
                 {% endfor %}
             </p>
         {% endif %}

--- a/source/index.twig
+++ b/source/index.twig
@@ -35,7 +35,8 @@ use: [posts]
                 <p class="tags">
                     Tags:
                     {% for tag in post.tags %}
-                        <a href="{{post.tag_html_index_permalinks[tag] }}">{{ tag }}</a>{% if not loop.last %}, {% endif %}
+                        {% set tag_slug = tag|url_encode(true) %}
+                        <a href="/news/tags/{{ tag_slug }}">{{ tag }}</a>{% if not loop.last %}, {% endif %}
                     {% endfor %}
                 </p>
             {% endif %}

--- a/source/news/tags/tag.twig
+++ b/source/news/tags/tag.twig
@@ -1,10 +1,9 @@
 ---
 layout: clean
-title: Tag Archive
+title: Arquivo de Tags
 generator: [posts_tag_index, pagination]
 pagination:
     provider: page.tag_posts
-
 ---
 
 {% block head_meta %}
@@ -13,35 +12,51 @@ pagination:
 {% endblock %}
 
 {% block title %}{{ page.title }} "{{ page.tag }}"{% endblock %}
-{% block content %}
-{% set year = '0' %}
-<h2>"{{ page.tag }}"</h2>
-{% for post in page.pagination.items %}
-{% set this_year %}{{ post.date | date("Y") }}{% endset %}
-{% if year != this_year %}
-  {% set month = '0' %}
-  {% set year = this_year %}
-{% endif %}
-{% set this_month %}{{ post.date | date("F") }}{% endset %}
-{% if month != this_month %}
-  {% set month = this_month %}
-  <h3>{{ month }} {{ year }}</h3>
-{% endif %}
-<article>
-  <div><a href="{{ site.url }}{{ post.url }}">{{ post.title }}</a></div>
-</article>
-{% endfor %}
 
-<div>
-{% if page.pagination.previous_page or page.pagination.next_page %}
-    <nav class="article clearfix">
-    {% if page.pagination.previous_page %}
-    <a class="previous" href="{{ site.url }}{{ page.pagination.previous_page.url }}" title="Previous Page"><span class="title">Previous Page</span></a>
-    {% endif %}
-    {% if page.pagination.next_page %}
-    <a class="next" href="{{ site.url }}{{ page.pagination.next_page.url }}" title="Next Page"><span class="title">Next Page</span></a>
-    {% endif %}
-    </nav>
-{% endif %}
-</div>
+{% block content %}
+<header class="random-bg">
+    <div class="inner"><h2>Posts com a tag "{{ page.tag }}"</h2></div>
+</header>
+
+<section id="archive" class="wrapper style5 special">
+    <div class="inner">
+
+        {% set year = '0' %}
+        {% for post in page.pagination.items %}
+            {% set this_year %}{{ post.date | date("Y") }}{% endset %}
+            {% if year != this_year %}
+                {% set month = '0' %}
+                {% set year = this_year %}
+            {% endif %}
+
+            {% set this_month %}{{ attribute(site.meses, post.date|date("n") - 1) }}{% endset %}
+            {% if month != this_month %}
+                {% set month = this_month %}
+                <h3>{{ month }} de {{ year }}</h3>
+            {% endif %}
+
+            <div><a href="{{ post.url }}">{{ post.title }}</a></div>
+        {% endfor %}
+
+        <aside>
+            {% if page.pagination.previous_page or page.pagination.next_page %}
+                <nav class="article">
+                    {% if page.pagination.previous_page %}
+                        <a class="button small special" href="{{ page.pagination.previous_page.url }}" title="Página anterior">
+                            <span class="title"><i class="fa fa-arrow-left"></i> Página anterior</span>
+                        </a>
+                    {% endif %}
+
+                    {% if page.pagination.next_page %}
+                        <a class="button small special" href="{{ page.pagination.next_page.url }}" title="Próxima página">
+                            <span class="title">Próxima página <i class="fa fa-arrow-right"></i></span>
+                        </a>
+                    {% endif %}
+                </nav>
+            {% endif %}
+        </aside>
+
+    </div>
+</section>
+
 {% endblock content %}


### PR DESCRIPTION
Ajustei a página de tags nos moldes da página de arquivo de notícias.

A página de arquivo de tags não estava no padrão do site, com o header e o fundo branco. Também alterei o código de exibição da data dos posts para ficar igual ao das notícias (antes estava em inglês e agora aparece em português)